### PR TITLE
[Faild] BOJ_20922_겹치는 건 싫어

### DIFF
--- a/Week 2/BOJ_실버 1_겹치는 건 싫어/Jongmin_solve.java
+++ b/Week 2/BOJ_실버 1_겹치는 건 싫어/Jongmin_solve.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        System.out.println(findMaxLength());
+    }
+
+    public static int findMaxLength() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n;
+        int k;
+        int headIdx=0;
+        int tailIdx=0;
+        int maxLength = 0;
+
+        int[] counts = new int[200001];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        int[] list = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+a
+        while(headIdx < n ){
+            if(counts[list[headIdx]] < k){
+                counts[list[headIdx]]++;
+                headIdx++;
+                maxLength = Math.max(headIdx - tailIdx, maxLength);
+            }else {
+                counts[list[tailIdx]]--;
+                tailIdx++;
+            }
+        }
+
+        return maxLength;
+    }
+}


### PR DESCRIPTION
## 문제 및 풀이과정
[겹치는 건 싫어](https://www.acmicpc.net/problem/20922)
소요 시간 : 3시간;;

풀이 과정: 

- 처음에는 단순히 키에 따라 카운트를 저장하면서 그 연속된 길이를 재다가 카운트가 k보다 크게 되면 거기서 끊어버렸음. 당연히 오답
- 키 값의 카운트를 증가시키다 k이상이 됐을때  앞 부분을 잘라내고 뒷 부분을 추가하면 더 길 수도 있음다는 생각이 들었음
-  header와 tail의 인덱스를 둬서 header가 앞서나가다 카운트가 k+1이 되는 순간 tail이 증가하면서 카운트에서 제거함.
알고리즘은 여기서 더 좋은 방법이 생각나지 않아 구현
처음에는 
1. 파이썬의 딕셔너리처럼 해시맵을 이용해서 카운트를 세었음.
2. 제출했으나 틀렸다고 나와 자바 문법의 미숙임이라 생각하고 리스트로 변경
3. 그래도 틀렸다고 해서 도대체 내 생각에는 맞는 풀이법인데 답이안나와서 그분의 도움을 받아 틀린 원인을 찾았음
 바로 maxLength의 갱신 위치였음.  k+1이 되는 순간에만 maxLength를 갱신하니 연속된 숫자가 초과되지 않고 입력 문자열의 길이가 최대 연속 길이일 때는  갱신이 안 된 거였음. 

## 궁금한 점
회전초밥도  오늘까진가요?
