### PR TITLE
[Solve] 월요일[수들의 합] + 화요일[수열]

### DIFF
--- a/Week 3/BOJ_실버3_수열/Jongmin_success.java
+++ b/Week 3/BOJ_실버3_수열/Jongmin_success.java
@@ -1,0 +1,47 @@
+import java.util.Scanner;
+
+public class Main {
+    // 전체 날짜의 길이
+    static int numDays;
+
+    // 연속적인 날짜 길이
+    static int consecutiveDays;
+
+    // 전체 온도
+    static int[] tempList;
+    public static void main(String[] args) {
+
+        //입력
+        Scanner scanner = new Scanner(System.in);
+
+        numDays = scanner.nextInt();
+        consecutiveDays = scanner.nextInt();
+
+        tempList = new int[numDays];
+        for (int i=0; i < numDays; i++){
+            tempList[i] = scanner.nextInt();
+        }
+
+        // 첫 M일  온도의 합
+        int sum=0;
+        for(int i=0; i<consecutiveDays;i++){
+            sum += tempList[i];
+        }
+
+        // 최대값을 첫 M일 온도의 합으로 설정
+        int maxTemp = sum;
+        int head=consecutiveDays;
+        int tail=0;
+
+        // 길이가 고정되었으므로 매일 다음 날짜의 온도를 추가하고 지난 날짜의 온도는 빼면서 sum이 max보다 크면 갱신합니다.
+        while(head < numDays){
+            sum+= tempList[head++];
+            sum -= tempList[tail++];
+            maxTemp = Math.max(maxTemp, sum);
+        }
+
+        // 출력
+        System.out.println(maxTemp);
+
+    }
+}

--- a/Week 3/BOJ_실버4_수들의 합 2/Jongmin_fail.java
+++ b/Week 3/BOJ_실버4_수들의 합 2/Jongmin_fail.java
@@ -1,0 +1,61 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int sizeOfList;
+    static int targetScore;
+    static int[] listNumber;
+
+    public static void main(String[] args) throws IOException {
+        getInput();
+
+        System.out.println(getCount());
+    }
+
+    static int getCount() {
+        int headIdx = 0;
+        int tailIdx = -1;
+        int sum = listNumber[0];
+        int count = 0;
+        while(headIdx < sizeOfList ){
+
+            if(sum == targetScore){
+                count++;
+
+                tailIdx++;
+                sum -= listNumber[tailIdx];
+
+                if(headIdx+1 < sizeOfList) {
+                    headIdx++;
+                    sum += listNumber[headIdx];
+                }
+            }
+            else if (sum < targetScore){
+                if(headIdx+1 < sizeOfList) {
+                    headIdx++;
+                    sum += listNumber[headIdx];
+                }
+            }
+            else{
+                tailIdx++;
+                sum -= listNumber[tailIdx];
+            }
+        }
+        return count;
+    }
+
+    static void getInput() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        sizeOfList = Integer.parseInt(st.nextToken());
+        targetScore = Integer.parseInt(st.nextToken());
+
+        listNumber = new int[sizeOfList];
+        st = new StringTokenizer(br.readLine());
+        for (int i=0; i < sizeOfList; i++){
+            listNumber[i] = Integer.parseInt(st.nextToken());
+        }
+    }
+}

--- a/Week 3/BOJ_실버4_수들의 합 2/Jongmin_sucess.java
+++ b/Week 3/BOJ_실버4_수들의 합 2/Jongmin_sucess.java
@@ -1,0 +1,53 @@
+import java.util.Scanner;
+
+public class Main {
+    static int sizeOfList;
+    static int targetScore;
+    static int[] listNumber;
+
+    public static void main(String[] args) {
+        getInput();
+
+        System.out.println(getCount());
+    }
+
+    static int getCount() {
+        int headIdx = 0;
+        int tailIdx = -1;
+        int sum = listNumber[0];
+        int count = 0;
+        while(headIdx < sizeOfList ){
+
+            if(sum == targetScore){
+                count++;
+                sum -= listNumber[++tailIdx];
+
+            }
+            else if (sum < targetScore){
+                if(headIdx+1 < sizeOfList) {
+                    headIdx++;
+                    sum += listNumber[headIdx];
+                }else{
+                    break;
+                }
+            }
+            else{
+                sum -= listNumber[++tailIdx];
+            }
+        }
+        return count;
+    }
+
+    static void getInput() {
+        Scanner scanner = new Scanner(System.in);
+
+        sizeOfList = scanner.nextInt();
+        targetScore = scanner.nextInt();
+
+        listNumber = new int[sizeOfList];
+
+        for (int i=0; i < sizeOfList; i++){
+            listNumber[i] = scanner.nextInt();
+        }
+    }
+}


### PR DESCRIPTION
# 개요
[수들의 합](https://www.acmicpc.net/problem/2003)
소요 시간: 2시간

## 문제 및 풀이과정
- head와 tail을 이용하여 head를 앞으로 이동하며 숫자를 더해가다가 targetScore보다 커지면 tail을 앞으로 이동하면서 숫자를 빼고 그 합이 targetScore와 같으면 카운트를 증가하도록 하였습니다
## 실패 이유
- 시간 초과가 나왔습니다. 어떻게 줄일 수 있을지 생각해보다 떠오르지 않아서 저의 벗에게 물어봤습니다.
- 그 친구가 scanner 쓰라고 해서 간결해서 쓰기로 했습니다
- 그건 부차적인 것 같고 가장 중요한 부분은 header가 index범위를 벗어나면 break로 빠져나오는 부분 같습니다.
- 매 번 while문을 돌 대 header나 tail이 한 칸씩 이동하므로 최 악의 경우 $$O(N) + O(N)=O(N)$$  이 되고 매번 head에 해당하는 숫자를 더하거나 tail에 해당하는 숫자를 빼니  $$O(N) \times O(1)$$ 라 시간이 초과될 줄 몰랐네요
- 아무래도 알고리즘 테스트는 되도록 불필요한 연산을 줄여야 통과할 수 있을 것 같습니다.

[수열](https://acmicpc.net/problem/2559) 
소요 시간: 30분

## 문제 및 풀이과정
- 월요일 문제와 거의 비슷하게 풀었는데 오히려 연속된 날의 길이는 입력값에서 정해져 있으므로  header 하나 더하고 tail하나 빼면서 header에 해당하는 온도는 더하고 tail에 해당하는 온도를 빼면서 최대값을 갱신하는 식으로 했습니다
- 시간 상으로는 월요일 문제에 비해 header와 tail이 같이 움직이므로 $1/2$이지만 빅 오 표기법으로는 $O(N)$이 될 것 같습니다. 

## 궁금한 점
