### PR TITLE
[Solved] PRG_레벨2_요격 시스템 [Solved] PRG_레벨1_문자열 마음대로 정렬하기 [Solved] PRG_레벨2_광물 캐기 [Solved] PRG_레벨2_H-Index

### DIFF
--- a/Week 4/PRG_레벨1_문자열 내 마음대로 저장하기/Jongmin_solved.java
+++ b/Week 4/PRG_레벨1_문자열 내 마음대로 저장하기/Jongmin_solved.java
@@ -1,0 +1,15 @@
+import java.util.*;
+
+class Solution {
+    public String[] solution(String[] strings, int n) {
+        Arrays.sort(strings,
+                (s1, s2)-> {
+                    if (s1.charAt(n) == s2.charAt(n)){
+                        return s1.compareTo(s2);
+                    }
+                    return (s1.substring(n)).compareTo(s2.substring(n));
+                }
+        );
+        return strings;
+    }
+}

--- a/Week 4/PRG_레벨2_H-Index/Jongmin_Solved.java
+++ b/Week 4/PRG_레벨2_H-Index/Jongmin_Solved.java
@@ -1,0 +1,21 @@
+import java.util.Arrays;
+import java.util.Collections;
+
+class Solution {
+    public int solution(int[] citations) {
+        int answer = 0;
+
+        Arrays.sort(citations);
+
+        for (int i = citations.length - 1; i >= 0; i--) {
+            if (citations[i] >= (citations.length - i)
+                    && ((i == 0) || (citations[i - 1] <= (citations.length - i)))
+            ) {
+                answer = citations.length - i;
+                break;
+            }
+        }
+
+        return answer;
+    }
+}

--- a/Week 4/PRG_레벨2_광물 캐기/Jongmin_solve.java
+++ b/Week 4/PRG_레벨2_광물 캐기/Jongmin_solve.java
@@ -1,0 +1,67 @@
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class Solution {
+    public int solution(int[] picks, String[] minerals) {
+
+        int[][] fatigues = {{1, 1, 1},{5, 1, 1},{25, 5, 1}};
+
+        int answer = 0;
+        int tools=0;
+        int max;
+        List<Integer> mineralPackages;
+
+        for(int tool:picks){
+            tools+=tool;
+        }
+        max = tools*5;
+
+        mineralPackages = new ArrayList<>();
+        for (int i=0 ; i <minerals.length && i < max; i++){
+            //광물 5개씩 묶습니다.
+            int idx = i / 5;
+            int valueToAdd = 0;
+            if (minerals[i].equals("diamond")) {
+                valueToAdd = 36;
+            } else if (minerals[i].equals("iron")) {
+                valueToAdd = 6;
+            } else {
+                valueToAdd = 1;
+            }
+            if (idx < mineralPackages.size()) {
+                mineralPackages.set(idx, mineralPackages.get(idx) + valueToAdd);
+            } else {
+                mineralPackages.add(valueToAdd);
+            }
+        }
+
+        // 5개씩 묶은 광물 정렬
+        mineralPackages.sort(Collections.reverseOrder());
+
+        int pickIdx = 0;
+        int idx = 0;
+        while(idx < mineralPackages.size()){
+            if(picks[pickIdx] == 0){
+                //곡괭이가 없으면 다음으로 강한 곡괭이로
+                pickIdx++;
+            }else{
+                int pack = mineralPackages.get(idx);
+
+                int diamonds = pack / 36;
+                answer += fatigues[pickIdx][0] * diamonds;
+
+                pack = pack - diamonds * 36;
+                int irons = pack / 6;
+                answer += fatigues[pickIdx][1] * irons;
+
+                int stones = pack - irons * 6;
+                answer += fatigues[pickIdx][2] * stones;
+                // 소모한 곡괭이 감소
+                picks[pickIdx]--;
+                idx++;
+            }
+        }
+        return answer;
+    }
+}

--- a/Week 4/PRG_레벨2_요격 시스템/Jongmin_solved.java
+++ b/Week 4/PRG_레벨2_요격 시스템/Jongmin_solved.java
@@ -1,0 +1,22 @@
+import java.util.*;
+class Solution {
+    public int solution(int[][] targets) {
+        int answer = 1;
+        int maxS = -1;
+        int minE = 100_000_001;
+
+        //정렬
+        Arrays.sort(targets, (t1, t2)-> (t1[0]-t2[0]));
+        // 처리
+        for (int[] target : targets){
+            maxS = Math.max(maxS, target[0]);
+            minE = Math.min(minE, target[1]);
+            if (minE <= maxS) {
+                answer++;
+                maxS = target[0];
+                minE = target[1];
+            }
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제 및 풀이과정

 [H-Index](https://school.programmers.co.kr/learn/courses/30/lessons/42747)
소요 시간 : 1시간
 - 논문을 인용 순서대로 내림차순으로 정렬 한 후 원하는 조건에 따라 i 번째 논문의 인용 수가 i보다 크고 i+1 번째는 i보다 작은 지점을 찾아서 H-index를 구했습니다.

### 어려웠던 점
 - 원시 타입의 데이터를 역순으로 정렬하기가 어려웠습니다. 때문에 오름차순으로 정렬한 후 뒷부분부터 내려가야해서 
 - i를 계산하는 데 실수가 있었습니다.
 - 그리고 i가 맨 마지막일 때 다음 i+1 (역순으로 했을 때는 -1) 인덱스가 없으니 이걸 처음에 생각하지 못해 exception이 발생했습니다.



## 문제 및 풀이과정

[광물 캐기](https://school.programmers.co.kr/learn/courses/30/lessons/172927)
소요 시간 : 1시간?
- 광물 캐기 
- 다섯 개씩 묶어서 다이아몬드, 철, 돌 순서대로 가중치를 매겨서 정렬하는 문제라고 생각했습니다.
- 5개씩 묶은 데이터를 6진법으로 환산하면 [다이아몬드의수][철의수][돌의수] 가 나오므로
- 다이아몬드 수에 36을 곱하고, 철의수에 6을 곱하고 돌의 수에 1을 곱해서 더하면 한 구러미(5개씩 모은)의 광물 정보가 나옵니다.
- 이걸 정렬해서 꾸러미의 숫자가 높은 것부터 다이아몬드 곡괭이, 철 곡괭이, 돌 곡괭이의 순서로 캐면서 피로도를 계산했습니다.

### 어려웠던 점
 - 원시 타입의 2차원 리스트를 정렬하는데 헷갈려서 5개씩 묶어서 1차원 배열로 정렬했는데 덕분에 정보를 언패킹 하는 과정을 거쳐야 해서 시간이 더 걸린 것 같습니다. 
 - 다차원 배열도 잘 다룰 수 있도록 자바 공부를 빡시게 해야겠습니다.
- 그냥 2차원 배열로 묶어서 정렬하면 데이터를 다시 뽑아오는데 시간이 안 걸렸을 것 같습니다.


## 문제 및 풀이과정

[문자열 마음대로 정렬하기](https://school.programmers.co.kr/learn/courses/30/lessons/12915)
소요 시간 : 30분
- 문자열 정렬 기준을 정하는 문제였던 것 같습니다.
- 처음에는 서브스트링만으로 정렬하니 당연히 틀렸습니다.
- 문제를 다시 보니 "[n] 번째 문자열이 같으면 사전순으로 정렬하라" 라는 말을 대충 듣고 반영을 하지 않아 생긴 문제였습니다.
- 문제를 자세히 읽어야하겠다는 생각이 들었습니다(항상 이 점이 문제같습니다.)

## 문제 및 풀이 과정
[요격 시스템](https://school.programmers.co.kr/learn/courses/30/lessons/181188
소요 시간 : 10분
- 괜히 시간 더 들여서 따로 객체를 구성하지 않고 
- 여러분들 소스코드 참고해서 어제 제가 생각했던 풀이 방법을 재연해봤습니다.
- 제 풀이법도 프로그래머스 통과하는 데는 문제가 없었습니다만, 여러분들 풀이가 더 이해하기 쉽고 깔끔했던 것 같습니다. 
- 
## 궁금한 점
