### PR TITLE
[Failed] LTC_Medium_Pacific Atlantic Water Flow

### DIFF
--- a/Week 9/LTC_Medium_Pacific Atlantic Water Flow/hyungjoon_failed.java
+++ b/Week 9/LTC_Medium_Pacific Atlantic Water Flow/hyungjoon_failed.java
@@ -1,0 +1,103 @@
+import java.util.*;
+
+class Solution {
+    static Queue<int[]> pq;
+    static Queue<int[]> aq;
+    static List<List<Integer>> list;
+    static int M;
+    static int N;
+
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+
+    public List<List<Integer>> pacificAtlantic(int[][] heights) {
+        list = new ArrayList<>();
+        M = heights.length;
+        N = heights[0].length;
+
+        for(int i = 0; i < M; i++){
+            for(int j = 0; j < N; j++){
+                pq = new LinkedList<>();
+                aq = new LinkedList<>();
+                if(pacificBfs(i, j, heights) && atlanticBfs(i, j, heights)){
+                    List<Integer> temp = new ArrayList<>();
+                    temp.add(i);
+                    temp.add(j);
+                    list.add(temp);
+                }
+            }
+        }
+
+        return list;
+
+    }
+
+    public boolean pacificBfs(int r, int c, int[][] heights){
+        pq.add(new int[]{r, c});
+        boolean[][] visited = new boolean[M][N];
+        for (int i = 0; i < M; i++) {
+            for (int j = 0; j < N; j++) {
+                visited[i][j] = false;
+            }
+        }
+
+        while(!pq.isEmpty()){
+            int[] temp = pq.poll();
+            r = temp[0];
+            c = temp[1];
+            visited[r][c] = true;
+
+            // 태평양과 인접한 칸이라면 true return
+            if((r == 0 && c >= 0 && c < N) || (c == 0 && r >= 0 && r < M)){
+                return true;
+            }
+
+            for(int i = 0; i < 4; i++){
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+                if(nr < 0 || nr >= M || nc < 0 || nc >= N || visited[nr][nc]){
+                    continue;
+                }
+                if(heights[nr][nc] <= heights[r][c]){
+                    pq.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean atlanticBfs(int r, int c, int[][] heights){
+        aq.add(new int[]{r, c});
+        boolean[][] visited = new boolean[M][N];
+        for (int i = 0; i < M; i++) {
+            for (int j = 0; j < N; j++) {
+                visited[i][j] = false;
+            }
+        }
+
+        while(!aq.isEmpty()){
+            int[] temp = aq.poll();
+            r = temp[0];
+            c = temp[1];
+            visited[r][c] = true;
+
+            // 대서양과 인접한 칸이라면 true return
+            if((r == M-1 && c >= 0 && c < N) || (c == N-1 && r >= 0 && r < M)){
+                return true;
+            }
+
+            for(int i = 0; i < 4; i++){
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+                if(nr < 0 || nr >= M || nc < 0 || nc >= N || visited[nr][nc]){
+                    continue;
+                }
+                if(heights[nr][nc] <= heights[r][c]){
+                    aq.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Week 9/LTC_Medium_Pacific Atlantic Water Flow/hyungjoon_solved.java
+++ b/Week 9/LTC_Medium_Pacific Atlantic Water Flow/hyungjoon_solved.java
@@ -1,0 +1,104 @@
+import java.util.*;
+
+/**
+ * 문제 : Pacific Atlantic Water Flow
+ * 난이도 : Medium
+ * 소요시간 : 100분
+ */
+class Solution {
+    static Queue<int[]> pq;
+    static Queue<int[]> aq;
+    static List<List<Integer>> list;
+    static int M;
+    static int N;
+
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+
+    public List<List<Integer>> pacificAtlantic(int[][] heights) {
+        pq = new LinkedList<>();
+        aq = new LinkedList<>();
+        list = new ArrayList<>();
+        M = heights.length;
+        N = heights[0].length;
+
+        // 양 옆 테두리 pq, aq에 넣어주기
+        for(int i = 0; i < M; i++){
+            pq.add(new int[]{i, 0});
+            aq.add(new int[]{i, N-1});
+        }
+
+        // 태평양 행 넣어주기 (위 테두리)
+        for(int i = 1; i < N; i++){
+            pq.add(new int[]{0, i});
+        }
+
+        // 대서양 행 넣어주기 (아래 테두리)
+        for(int i = 0; i < N-1; i++){
+            aq.add(new int[]{M-1, i});
+        }
+
+        // 태평양과 대서양의 테두리만 bfs 수행
+        int pacificVisited[][] = pacificBfs(heights);
+        int atlanticVisited[][] = atlanticBfs(heights);
+
+        for(int i = 0; i < M; i++){
+            for(int j = 0; j < N; j++){
+                if(pacificVisited[i][j] == 1 && atlanticVisited[i][j] == 1){
+                    List<Integer> temp = List.of(i, j);
+                    list.add(temp);
+                }
+            }
+        }
+
+        return list;
+
+    }
+
+    public int[][] pacificBfs(int[][] heights){
+        int[][] visited = new int[M][N];
+
+        while(!pq.isEmpty()){
+            int[] temp = pq.poll();
+            int r = temp[0];
+            int c = temp[1];
+            visited[r][c] = 1;
+
+            for(int i = 0; i < 4; i++){
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+                if(nr < 0 || nr >= M || nc < 0 || nc >= N || visited[nr][nc] == 1){
+                    continue;
+                }
+                if(heights[nr][nc] >= heights[r][c]){
+                    pq.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return visited;
+    }
+
+    public int[][] atlanticBfs(int[][] heights){
+        int[][] visited = new int[M][N];
+        while(!aq.isEmpty()){
+            int[] temp = aq.poll();
+            int r = temp[0];
+            int c = temp[1];
+            visited[r][c] = 1;
+
+            for(int i = 0; i < 4; i++){
+                int nr = r + dr[i];
+                int nc = c + dc[i];
+                if(nr < 0 || nr >= M || nc < 0 || nc >= N || visited[nr][nc] == 1){
+                    continue;
+                }
+                if(heights[nr][nc] >= heights[r][c]){
+                    aq.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return visited;
+    }
+
+}


### PR DESCRIPTION
## 문제 및 풀이과정
[Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow)
소요 시간 : 100분  
- BFS로 풀 수 있는 문제였습니다.
- 처음엔 모든 셀에서 BFS를 수행해서, 각각 태평양과 대서양에 닿을 수 있는 곳이면 정답 리스트에 추가하는 방식으로 진행했으나, 2문제를 남기고 시간 초과가 발생했습니다.
- 문제는 모든 셀에서 BFS를 수행했기 떄문입니다. 방법을 모르겠어서 답지를 봤고, 결국은 바다의 테두리에서 BFS만 수행하는 것이 핵심이었습니다.
- 즉, 바다로부터 내륙으로 뻗어나가야 합니다.
- 굉장히 좋은 문제였던 것 같습니다. 재밌었고.. 혼자 풀고싶어서 시간을 투자했지만 풀지 못했네요 ㅠㅠ


## 궁금한 점
