### PR TITLE
[Solved] PRG_레벨2_연속된 부분 수열의 합

### DIFF
--- a/Week 10/PRG_레벨2_연속된 부분 수열의 합/Jongmin_solved.java
+++ b/Week 10/PRG_레벨2_연속된 부분 수열의 합/Jongmin_solved.java
@@ -1,0 +1,36 @@
+
+class Solution {
+    public int[] solution(int[] sequence, int k) {
+        int[] answer = new int[2];
+
+        answer[0] = 0;
+        answer[1] = sequence.length;
+
+        int lidx = 0;
+        int ridx = 0;
+        int sum=0;
+        for(int i=lidx; i<=ridx; i++){
+            sum += sequence[i];
+        }
+
+        while(lidx<sequence.length && ridx<sequence.length){
+
+            if( sum < k){
+                if(ridx+1 < sequence.length) sum += sequence[++ridx];
+                else break;
+            }else if( sum > k ){
+                sum -= sequence[lidx++];
+            }else{
+                if((ridx - lidx) < (answer[1] - answer[0]) ){
+                    answer[0] = lidx;
+                    answer[1] = ridx;
+                }
+                sum -= sequence[lidx++];
+
+            }
+        }
+
+        return answer;
+
+    }
+}


### PR DESCRIPTION
## 문제 및 풀이과정

[연속된 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/178870)
소요 시간 : 30분  
- 투 포인터로 부분 수열의 처음과 끝을 나타내고 부분 수열의 합이 k보다 작으면 부분 수열의 길이를 늘리고 크면 부분 수열의 길이를 줄이는 방식을 썼습니다.
- 문제 조건이 가장 짧은 부분 수열을 구하는 것이기 때문에 두 idx를 끝까지 보내도록 했습니다. 
- 예외가 발생하면 뒤늦게 조건을 추가하게 되는데 이게 알고리즘을 처음부터 완벽하게 잘 못짜서 그런 것 같습니다.
- 

## 궁금한 점
